### PR TITLE
Fix unit references in .service files

### DIFF
--- a/opennebula-mysqld.service
+++ b/opennebula-mysqld.service
@@ -2,7 +2,7 @@
 Description=OpenNebula management
 After=network.target local-fs.target remote-fs.target mysqld.service 
 Requires=mysqld.service
-Conflicts=opennebula
+Conflicts=opennebula.service
 
 [Service]
 User=oneadmin

--- a/opennebula.service
+++ b/opennebula.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenNebula management
 After=network.target local-fs.target remote-fs.target mysqld.service 
-Conflicts=opennebula-mysqld
+Conflicts=opennebula-mysqld.service
 
 [Service]
 User=oneadmin


### PR DESCRIPTION
This prevents errors like the following from being logged when e.g.
`systemctl daemon-reload` is executed:

```
Sep 09 16:30:33 beech systemd[1]: [/usr/lib/systemd/system/opennebula-mysqld.service:5] Failed to add dependency on opennebula, ignoring: Invalid argument
Sep 09 16:30:33 beech systemd[1]: [/usr/lib/systemd/system/opennebula.service:4] Failed to add dependency on opennebula-mysqld, ignoring: Invalid argument
```
