### PR TITLE
Use all CPU cores when compiling with scons

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -132,7 +132,7 @@ build() {
   ###########################################################################
 
   # This builds the vanilla OpenNebula package. Tweak this line as desired.
-  scons new_xmlrpc=yes
+  scons -j "$(nproc)" new_xmlrpc=yes
 }
 
 package() {


### PR DESCRIPTION
`nproc` is provided by core/coreutils, and is therefore assumed to be
present. (Scons doesn't seem to care about the `MAKEFLAGS` setting in
`/etc/makepkg.conf`.)
