### PR TITLE
Drop references to self-contained install

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -121,13 +121,8 @@ build() {
   ###########################################################################
   ##                                                                       ##
   ## It is highly recommended that you read the documentation and tweak    ##
-  ##     the PKGBUILD accordingly:                                         ##
+  ## the PKGBUILD accordingly:                                             ##
   ## http://docs.opennebula.org/stable/integration/references/compile.html ##
-  ##                                                                       ##
-  ## This package assumes a self-contained install. If you do NOT want a   ##
-  ##     self-contained install, then remove `-d /srv/cloud/one` from the  ##
-  ##     package() function and MAKE SURE you properly change the          ##
-  ##     appropriate sections of opennebula-unstable.install               ##
   ##                                                                       ##
   ###########################################################################
 


### PR DESCRIPTION
The comments in `build()` state that a self-contained install is
performed. However, this does not appear to be true. According to the
official documentation, a self-contained installation is only done if
the `-d` option is passed to `install.sh`; otherwise, a system-wide
installation is performed.

See: http://docs.opennebula.org/5.0/integration/references/compile.html
