### PR TITLE
Support mysql by default

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,7 +28,8 @@ depends=('ruby>=1.8.7'
          'ruby-nokogiri')
 makedepends=('xmlrpc-c>=1.31'
              'pkgconfig'
-             'scons>=0.98')
+             'scons>=0.98'
+             'libmariadbclient')
 optdepends=('nfs-utils: for using the shared file system storage model'
             'mariadb>=5.1: optional replacement for SQLite as the DB back-end'
             'libmariadbclient>=5.1: required if using MariaDB/MySQL instead of SQLite'
@@ -127,7 +128,7 @@ build() {
   ###########################################################################
 
   # This builds the vanilla OpenNebula package. Tweak this line as desired.
-  scons -j "$(nproc)" new_xmlrpc=yes
+  scons -j "$(nproc)" new_xmlrpc=yes mysql=yes
 }
 
 package() {


### PR DESCRIPTION
The official documentation strongly suggests that users use mysql or
mariadb instead of sqlite. Consequently, it's likely that opennebula
users will attempt to do so, and will be frustrated if support is
unavailable. In my opinion, it's sensible to support this common use
case out of the box.

Add libmariadbclient to `makedepends`.
